### PR TITLE
98 error when optimisation step size less than 1 clover hpc

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clover-energy
-version = 5.0.2
+version = 5.0.3
 author = Phil Sandwell, Ben Winchester and Hamish Beath
 author_email = philip.sandwell@gmail.com,benedict.winchester@gmail.com,hamishbeath@outlook.com
 description = Continuous Lifetime Optimisation of Variable Electricity Resources

--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -17,7 +17,7 @@ the clover module from the command-line interface.
 
 """
 
-__version__ = "5.0.2"
+__version__ = "5.0.3"
 
 import datetime
 import logging

--- a/src/clover/optimisation/__utils__.py
+++ b/src/clover/optimisation/__utils__.py
@@ -1014,14 +1014,10 @@ def recursive_iteration(  # pylint: disable=too-many-locals
 
         # Determine the converter sizes.
         if not all(isinstance(value, int) for value in component_sizes.values()):
-            logger.error(
+            logger.info(
                 "%sNon-integer component sizes were specified, exiting.%s",
                 BColours.fail,
                 BColours.endc,
-            )
-            raise InputFileError(
-                "optimisation inputs",
-                "Component size inputs specified non-integer converter sizes.",
             )
         converters = converters_from_sizing(
             {

--- a/src/clover/optimisation/optimisation.py
+++ b/src/clover/optimisation/optimisation.py
@@ -732,6 +732,24 @@ def _simulation_iteration(  # pylint: disable=too-many-locals, too-many-statemen
         ]
     ] = []
 
+    # Check that a valid set of sizes were passed in and warn the user if not.
+    if not isinstance(pv_sizes.step, int) and minigrid.pv_panel.pv_unit_overrided:
+        logger.warning(
+            "The pv-panel unit size of %s is not an integer, and a non-integer pv step "
+            "size of %s has also been selected.",
+            round(minigrid.pv_panel.pv_unit, 2),
+            round(pv_sizes.step, 2),
+        )
+    if not isinstance(storage_sizes.step, int) and not isinstance(
+        minigrid.battery.capacity, int
+    ):
+        logger.warning(
+            "The battery capacity of %s is not an integer capacity, and a non-integer "
+            "storage step size of %s has also been selected.",
+            round(minigrid.battery.capacity, 2),
+            round(storage_sizes.step, 2),
+        )
+
     simulation_cw_pvt_system_size: List[int] = sorted(
         range(
             int(cw_pvt_system_size.min),
@@ -765,14 +783,14 @@ def _simulation_iteration(  # pylint: disable=too-many-locals, too-many-statemen
         reverse=True,
     )
     simulation_pv_sizes: List[int] = sorted(
-        range(int(pv_sizes.min), int(pv_size_max + pv_sizes.step), int(pv_sizes.step)),
+        np.arange(pv_sizes.min, pv_size_max + pv_sizes.step, pv_sizes.step),
         reverse=True,
     )
     simulation_storage_sizes: List[int] = sorted(
-        range(
-            int(storage_sizes.min),
-            int(storage_size_max + storage_sizes.step),
-            int(storage_sizes.step),
+        np.arange(
+            storage_sizes.min,
+            storage_size_max + storage_sizes.step,
+            storage_sizes.step,
         ),
         reverse=True,
     )

--- a/src/clover/optimisation/optimisation.py
+++ b/src/clover/optimisation/optimisation.py
@@ -740,15 +740,16 @@ def _simulation_iteration(  # pylint: disable=too-many-locals, too-many-statemen
             round(minigrid.pv_panel.pv_unit, 2),
             round(pv_sizes.step, 2),
         )
-    if not isinstance(storage_sizes.step, int) and not isinstance(
-        minigrid.battery.capacity, int
-    ):
-        logger.warning(
-            "The battery capacity of %s is not an integer capacity, and a non-integer "
-            "storage step size of %s has also been selected.",
-            round(minigrid.battery.capacity, 2),
-            round(storage_sizes.step, 2),
-        )
+    if minigrid.battery is not None:
+        if not isinstance(storage_sizes.step, int) and not isinstance(
+            minigrid.battery.capacity, int
+        ):
+            logger.warning(
+                "The battery capacity of %s is not an integer capacity, and a non-integer "
+                "storage step size of %s has also been selected.",
+                round(minigrid.battery.capacity, 2),
+                round(storage_sizes.step, 2),
+            )
 
     simulation_cw_pvt_system_size: List[int] = sorted(
         range(

--- a/src/clover/simulation/storage_utils.py
+++ b/src/clover/simulation/storage_utils.py
@@ -177,6 +177,9 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
     """
     Represents a battery within CLOVER.
 
+    .. attribute:: capacity
+        The capacity of the battery in kWh.
+
     .. attribute:: charge_rate
         The rate of charge of the :class:`Battery`.
 
@@ -199,6 +202,7 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
 
     def __init__(
         self,
+        capacity: float,
         cycle_lifetime: int,
         leakage: float,
         maximum_charge: float,
@@ -216,6 +220,8 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
         Instantiate a :class:`Battery` instance.
 
         Inputs:
+            - capacity:
+                The capacity of the battery in kWh.
             - cycle_lifetime:
                 The number of cycles for which the :class:`Battery` instance can
                 perform.
@@ -247,6 +253,7 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
         """
 
         super().__init__(cycle_lifetime, leakage, maximum_charge, minimum_charge, name)
+        self.capacity: float = capacity
         self.charge_rate: float = charge_rate
         self.conversion_in: float = conversion_in
         self.conversion_out: float = conversion_out
@@ -268,6 +275,7 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
             "Battery("
             + f"{self.label} storing {self.resource_type.value} loads, "
             + f"name={self.name}, "
+            + f"capacity={self.capacity}, "
             + f"cycle_lifetime={self.cycle_lifetime} cycles, "
             + f"leakage={self.leakage}, "
             + f"maximum_charge={self.maximum_charge}, "
@@ -294,7 +302,7 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
         return (
             "Battery("
             + f"{self.label} storing {self.resource_type.value} loads, "
-            + f"name={self.name}"
+            + f"name={self.name}, capacity={self.capacity}"
             + ")"
         )
 
@@ -313,6 +321,7 @@ class Battery(_BaseStorage, label="battery", resource_type=ResourceType.ELECTRIC
         """
 
         return cls(
+            storage_data["capacity"] if "capacity" in storage_data else 1,
             storage_data["cycle_lifetime"],
             storage_data["leakage"],
             storage_data["maximum_charge"],


### PR DESCRIPTION
### Description
This pull request is being opened to resolve issue #98 where non-integer step sizes were not supported in optimisations. This pull request therefore modifies the production code of CLOVER, and a new version tag, v5.0.3, will be introduced.

### Linked Issues
This pull request:
* closes #98 

### Unit tests
This pull request does not affect any of the unit testing within CLOVER.