### PR TITLE
116 unmet diesel

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -19,5 +19,5 @@
     ],
     "title": "CLOVER",
     "upload_type": "software",
-    "version": "v5.0.4"
+    "version": "v5.0.5"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,6 @@ authors:
     given-names: Philip
     orcid: https://orcid.org/0000-0003-1117-5095
 title: CLOVER
-version: v5.0.4
+version: v5.0.5
 doi: 10.5281/zenodo.6925535
-date-released: 2022-08-03
+date-released: 2022-08-22

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clover-energy
-version = 5.0.4
+version = 5.0.5
 author = Phil Sandwell, Ben Winchester and Hamish Beath
 author_email = philip.sandwell@gmail.com,benedict.winchester@gmail.com,hamishbeath@outlook.com
 description = Continuous Lifetime Optimisation of Variable Electricity Resources

--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -17,7 +17,7 @@ the clover module from the command-line interface.
 
 """
 
-__version__ = "5.0.4"
+__version__ = "5.0.5"
 
 import datetime
 import logging

--- a/src/clover/__utils__.py
+++ b/src/clover/__utils__.py
@@ -705,6 +705,10 @@ class DieselMode(enum.Enum):
     - BACKUP:
         The diesel generator is used as a 'load-following' backup generator.
 
+    - BACKUP_UNMET:
+        The diesel generator is used as a 'load-following' backup generator, 
+        with unmet energy as the threshold criterion.
+
     - CYCLE_CHARGING:
         The diesel generator is operated as a dynamic 'cycle-charging' generator.
 
@@ -714,6 +718,7 @@ class DieselMode(enum.Enum):
     """
 
     BACKUP = "backup"
+    BACKUP_UNMET = "backup_unmet"
     CYCLE_CHARGING = "cycle_charging"
     DISABLED = "disabled"
 

--- a/src/clover/__utils__.py
+++ b/src/clover/__utils__.py
@@ -706,7 +706,7 @@ class DieselMode(enum.Enum):
         The diesel generator is used as a 'load-following' backup generator.
 
     - BACKUP_UNMET:
-        The diesel generator is used as a 'load-following' backup generator, 
+        The diesel generator is used as a 'load-following' backup generator,
         with unmet energy as the threshold criterion.
 
     - CYCLE_CHARGING:
@@ -2010,8 +2010,8 @@ class Scenario:
 
         diesel_scenario = DieselScenario(
             scenario_inputs["diesel"]["backup"]["threshold"]
-            if scenario_inputs["diesel"][MODE] in (DieselMode.BACKUP.value, 
-            DieselMode.BACKUP_UNMET.value)
+            if scenario_inputs["diesel"][MODE]
+            in (DieselMode.BACKUP.value, DieselMode.BACKUP_UNMET.value)
             else None,
             DieselMode(scenario_inputs["diesel"][MODE]),
         )

--- a/src/clover/__utils__.py
+++ b/src/clover/__utils__.py
@@ -2010,7 +2010,8 @@ class Scenario:
 
         diesel_scenario = DieselScenario(
             scenario_inputs["diesel"]["backup"]["threshold"]
-            if scenario_inputs["diesel"][MODE] == DieselMode.BACKUP.value
+            if scenario_inputs["diesel"][MODE] in (DieselMode.BACKUP.value, 
+            DieselMode.BACKUP_UNMET.value)
             else None,
             DieselMode(scenario_inputs["diesel"][MODE]),
         )

--- a/src/clover/simulation/diesel.py
+++ b/src/clover/simulation/diesel.py
@@ -26,7 +26,14 @@ from typing import Any, Dict, Tuple
 import numpy as np  # pylint: disable=import-error
 import pandas as pd
 
-from ..__utils__ import BColours, ELECTRIC_POWER, DieselMode, InputFileError, NAME, ResourceType
+from ..__utils__ import (
+    BColours,
+    ELECTRIC_POWER,
+    DieselMode,
+    InputFileError,
+    NAME,
+    ResourceType,
+)
 from ..conversion.conversion import MAXIMUM_OUTPUT, Converter
 
 
@@ -175,7 +182,7 @@ class DieselWaterHeater(Converter):
 
 
 def _find_deficit_threshold_blackout(
-     unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float
+    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float
 ) -> float:
     """
     Identifies the threshold energy level at which the diesel backup generator turns on
@@ -204,11 +211,13 @@ def _find_deficit_threshold_blackout(
 
     if reliability_difference <= 0.0:
         return None
-    
+
     return np.percentile(unmet_energy, percentile_threshold)
 
 
-def _find_deficit_threshold_unmet(unmet_energy: pd.DataFrame, backup_threshold: float, total_electric_load: float) -> float:
+def _find_deficit_threshold_unmet(
+    unmet_energy: pd.DataFrame, backup_threshold: float, total_electric_load: float
+) -> float:
     """
     Identifies the threshold energy level at which the diesel backup generator turns on
     when the threshold criterion is unmet energy.
@@ -240,9 +249,9 @@ def _find_deficit_threshold_unmet(unmet_energy: pd.DataFrame, backup_threshold: 
     sorted_unmet_energy = sorted(unmet_energy.values)
 
     # Loop through hours attributing unmet energy to diesel generator (largest first)
-    attributed_unmet_energy:float = 0
-    energy_threshold:float 
-    
+    attributed_unmet_energy: float = 0
+    energy_threshold: float
+
     while attributed_unmet_energy < total_electric_load * reliability_difference:
         energy_threshold = sorted_unmet_energy.pop()
         attributed_unmet_energy += energy_threshold
@@ -251,7 +260,11 @@ def _find_deficit_threshold_unmet(unmet_energy: pd.DataFrame, backup_threshold: 
 
 
 def _find_deficit_threshold(
-    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float, total_electric_load: float, diesel_mode: DieselMode
+    unmet_energy: pd.DataFrame,
+    blackouts: pd.DataFrame,
+    backup_threshold: float,
+    total_electric_load: float,
+    diesel_mode: DieselMode,
 ) -> float:
     """
     Identifies the threshold energy level at which the diesel backup generator turns on.
@@ -272,18 +285,23 @@ def _find_deficit_threshold(
 
     # Find the blackout percentage is mode using blackout criterion
     if diesel_mode == DieselMode.BACKUP:
-        return _find_deficit_threshold_blackout(unmet_energy, blackouts, 
-        backup_threshold)
-    
+        return _find_deficit_threshold_blackout(
+            unmet_energy, blackouts, backup_threshold
+        )
+
     # Find the blackout percentage is mode using unmet energy criterion
     if diesel_mode == DieselMode.BACKUP_UNMET:
-        return _find_deficit_threshold_unmet(unmet_energy, backup_threshold, 
-        total_electric_load)
-
+        return _find_deficit_threshold_unmet(
+            unmet_energy, backup_threshold, total_electric_load
+        )
 
 
 def get_diesel_energy_and_times(
-    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float, total_electric_load: float, diesel_mode: DieselMode
+    unmet_energy: pd.DataFrame,
+    blackouts: pd.DataFrame,
+    backup_threshold: float,
+    total_electric_load: float,
+    diesel_mode: DieselMode,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Finds times when the load is greater than the energy threshold.
@@ -311,7 +329,9 @@ def get_diesel_energy_and_times(
         unmet_energy, blackouts, backup_threshold, total_electric_load, diesel_mode
     )
     if energy_threshold is None:
-        return pd.DataFrame([0]*len(unmet_energy)), pd.DataFrame([0]*len(unmet_energy))
+        return pd.DataFrame([0] * len(unmet_energy)), pd.DataFrame(
+            [0] * len(unmet_energy)
+        )
 
     diesel_energy = pd.DataFrame(
         unmet_energy.values * (unmet_energy >= energy_threshold).values

--- a/src/clover/simulation/diesel.py
+++ b/src/clover/simulation/diesel.py
@@ -253,7 +253,7 @@ def _find_deficit_threshold_unmet(unmet_energy: pd.DataFrame, backup_threshold: 
 
 
 def _find_deficit_threshold(
-    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float
+    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float, total_electric_load: float, diesel_mode: DieselMode
 ) -> float:
     """
     Identifies the threshold energy level at which the diesel backup generator turns on.
@@ -279,13 +279,13 @@ def _find_deficit_threshold(
     
     # Find the blackout percentage is mode using unmet energy criterion
     if diesel_mode == DieselMode.BACKUP_UNMET:
-        blackout_percentage = float(unmet_energy.mean(axis=0)) 
-
+        return _find_deficit_threshold_unmet(unmet_energy, backup_threshold, 
+        total_electric_load)
 
 
 
 def get_diesel_energy_and_times(
-    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float
+    unmet_energy: pd.DataFrame, blackouts: pd.DataFrame, backup_threshold: float, total_electric_load: float, diesel_mode: DieselMode
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """
     Finds times when the load is greater than the energy threshold.
@@ -310,7 +310,7 @@ def get_diesel_energy_and_times(
     """
 
     energy_threshold = _find_deficit_threshold(
-        unmet_energy, blackouts, backup_threshold
+        unmet_energy, blackouts, backup_threshold, total_electric_load, diesel_mode
     )
 
     diesel_energy = pd.DataFrame(

--- a/src/clover/simulation/diesel.py
+++ b/src/clover/simulation/diesel.py
@@ -202,12 +202,10 @@ def _find_deficit_threshold_blackout(
     reliability_difference = blackout_percentage - backup_threshold
     percentile_threshold = 100.0 * (1.0 - reliability_difference)
 
-    if reliability_difference > 0.0:
-        energy_threshold: float = np.percentile(unmet_energy, percentile_threshold)
-    else:
-        energy_threshold = np.max(unmet_energy)[0] + 1.0
-
-    return energy_threshold
+    if reliability_difference <= 0.0:
+        return None
+    
+    return np.percentile(unmet_energy, percentile_threshold)
 
 
 def _find_deficit_threshold_unmet(unmet_energy: pd.DataFrame, backup_threshold: float, total_electric_load: float) -> float:
@@ -312,6 +310,8 @@ def get_diesel_energy_and_times(
     energy_threshold = _find_deficit_threshold(
         unmet_energy, blackouts, backup_threshold, total_electric_load, diesel_mode
     )
+    if energy_threshold is None:
+        return pd.DataFrame([0]*len(unmet_energy)), pd.DataFrame([0]*len(unmet_energy))
 
     diesel_energy = pd.DataFrame(
         unmet_energy.values * (unmet_energy >= energy_threshold).values

--- a/src/clover/simulation/diesel.py
+++ b/src/clover/simulation/diesel.py
@@ -274,8 +274,12 @@ def _find_deficit_threshold(
             Desired level of reliability after diesel backup
         - blackouts:
             Current blackout profile before diesel backup
+        - diesel_mode:
+            The diesel mode used in the scenario inputs file
         - unmet_energy:
             Load profile of currently unment energy
+        - total_electric_load:
+            The total electric load placed on the system (kWh).
 
     Outputs:
         - energy_threshold:
@@ -314,8 +318,12 @@ def get_diesel_energy_and_times(
             Desired level of reliability after diesel backup
         - blackouts:
             Current blackout profile before diesel backup
+        - diesel_mode:
+            The diesel mode used in the scenario inputs file
         - unmet_energy:
             Load profile of currently unment energy
+        - total_electric_load:
+            The total electric load placed on the system (kWh).
 
     Outputs:
         - diesel_energy:

--- a/src/clover/simulation/energy_system.py
+++ b/src/clover/simulation/energy_system.py
@@ -125,7 +125,7 @@ def _calculate_backup_diesel_generator_usage(
         blackout_times,
         float(scenario.diesel_scenario.backup_threshold),
         total_electric_load,
-        scenario.diesel_scenario.mode
+        scenario.diesel_scenario.mode,
     )
     diesel_capacity: float = float(math.ceil(np.max(diesel_energy, axis=0)))
     diesel_fuel_usage = pd.DataFrame(
@@ -1721,7 +1721,11 @@ def run_simulation(  # pylint: disable=too-many-locals, too-many-statements
             diesel_times,
             unmet_energy,
         ) = _calculate_backup_diesel_generator_usage(
-            blackout_times, minigrid, scenario, float(np.sum(processed_total_electric_load)), unmet_energy
+            blackout_times,
+            minigrid,
+            scenario,
+            float(np.sum(processed_total_electric_load)),
+            unmet_energy,
         )
     elif scenario.diesel_scenario.mode == DieselMode.CYCLE_CHARGING:
         logger.error(

--- a/src/clover/simulation/energy_system.py
+++ b/src/clover/simulation/energy_system.py
@@ -90,8 +90,6 @@ def _calculate_backup_diesel_generator_usage(
             The :class:`Minigrid` being considered.
         - scenario:
             The :class:`Scenario` being used for the run.
-        - diesel_mode:
-            The diesel mode used in the scenario inputs file
         - unmet_energy:
             Load profile of currently unment energy
         - total_electric_load:

--- a/src/clover/simulation/energy_system.py
+++ b/src/clover/simulation/energy_system.py
@@ -90,8 +90,12 @@ def _calculate_backup_diesel_generator_usage(
             The :class:`Minigrid` being considered.
         - scenario:
             The :class:`Scenario` being used for the run.
+        - diesel_mode:
+            The diesel mode used in the scenario inputs file
         - unmet_energy:
-            The energy demand which went unmet through renewables.
+            Load profile of currently unment energy
+        - total_electric_load:
+            The total electric load placed on the system (kWh).
 
     Outputs:
         - diesel_capacity:


### PR DESCRIPTION
### Description
Updates to allow unmet energy as a threshold criterion when using backup diesel.
This will bring CLOVER to 5.0.5. 

### Linked Issues
This pull request:
* closes issue #116 

### Unit tests
This pull request:
Does not change any unit tests.

