### PR TITLE
138 hpc does not use output name from inputs file

### DIFF
--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -678,7 +678,7 @@ def main(  # pylint: disable=too-many-locals, too-many-statements
         os.path.join(auto_generated_files_directory, "solar"),
         generation_inputs,
         location,
-        f"{parsed_args.location}_{solar.SOLAR_LOGGER_NAME}",
+        f"{parsed_args.location}_{solar.SOLAR_LOGGER_NAME}{run_number_string}",
         parsed_args.refetch,
         minigrid.pv_panel,
         num_ninjas,

--- a/src/clover/scripts/hpc.py
+++ b/src/clover/scripts/hpc.py
@@ -91,6 +91,8 @@ def main(args: List[Any]) -> None:
     clover_arguments = [
         "--location",
         hpc_run.location,
+        "--output",
+        hpc_run.output,
     ]
 
     if hpc_run.total_load:

--- a/src/clover/scripts/hpc_utils.py
+++ b/src/clover/scripts/hpc_utils.py
@@ -93,6 +93,9 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
     .. attribute:: location
         The name of the location.
 
+    .. attribute:: output
+        The name of the ouptut file to use.
+
     .. attribute:: total_load
         Whether a total-load file is being used (True) or not (False).
 
@@ -107,7 +110,7 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
     type: HpcRunType
 
     def __init__(
-        self, location: str, total_load: bool, total_load_file: Optional[str] = None
+        self, location: str, output: str, total_load: bool, total_load_file: Optional[str] = None
     ) -> None:
         """
         Instantiate a :class:`_BaseHpcRun` instance.
@@ -115,6 +118,8 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
         Inputs:
             - location:
                 The name of the location to use.
+            - output:
+                The name of the output file to use.
             - total_load:
                 Whether a total-load file should be used.
             - total_load_file:
@@ -123,6 +128,7 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
         """
 
         self.location = location
+        self.output = output
         self.total_load = total_load
         self.total_load_file = total_load_file
 
@@ -150,6 +156,7 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
 
         return (
             f"HpcRun(type={self.type}, location={self.location}"
+            + f", output={self.output}"
             + f", total_load={self.total_load}"
             + (
                 f", total_load_file={self.total_load_file}"
@@ -173,6 +180,7 @@ class HpcOptimisation(
         location: str,
         optimisation: List[Dict[str, Any]],
         optimisation_inputs_data: Dict[str, Any],
+        output: str,
         total_load: bool,
         total_load_file: Optional[str] = None,
     ) -> None:
@@ -187,6 +195,8 @@ class HpcOptimisation(
                 as a single entry in a `list` for easy temporary file generation.
             - optimisation_inputs_data:
                 The input data for optimisations in general.
+            - output:
+                The name of the output file to use.
             - total_load:
                 Whether a total-load file should be used.
             - total_load_file:
@@ -194,7 +204,7 @@ class HpcOptimisation(
 
         """
 
-        super().__init__(location, total_load, total_load_file)
+        super().__init__(location, output, total_load, total_load_file)
         self.optimisation: List[Dict[str, Any]] = optimisation
         self.optimisation_inputs_data: Dict[str, Any] = optimisation_inputs_data
 
@@ -245,6 +255,7 @@ class HpcOptimisation(
             input_data["location"],
             optimisation,
             optimisation_inputs_data,
+            input_data.get("output", "optimisation_output"),
             total_load,
             total_load_file,
         )
@@ -287,6 +298,7 @@ class HpcSimulation(
         self,
         location: str,
         pv_system_size: float,
+        output: str,
         scenario: str,
         storage_size: float,
         total_load: bool,
@@ -298,6 +310,8 @@ class HpcSimulation(
         Inputs:
             - location:
                 The name of the location to use for the simulation(s).
+            - output:
+                The name of the output file to use.
             - pv_system_size:
                 The size of the PV system installed.
             - scenario:
@@ -311,7 +325,7 @@ class HpcSimulation(
 
         """
 
-        super().__init__(location, total_load, total_load_file)
+        super().__init__(location, output, total_load, total_load_file)
         self.pv_system_size = pv_system_size
         self.scenario = scenario
         self.storage_size = storage_size
@@ -340,6 +354,8 @@ class HpcSimulation(
         else:
             total_load = True
             total_load_file = total_load_input
+
+        output: str = input_data.get("ouptut", "simulation_outputs")
 
         try:
             pv_system_size: float = float(input_data["pv_system_size"])
@@ -385,6 +401,7 @@ class HpcSimulation(
 
         return cls(
             input_data["location"],
+            output,
             pv_system_size,
             scenario,
             storage_size,

--- a/src/clover/scripts/hpc_utils.py
+++ b/src/clover/scripts/hpc_utils.py
@@ -94,7 +94,7 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
         The name of the location.
 
     .. attribute:: output
-        The name of the ouptut file to use.
+        The name of the output file to use.
 
     .. attribute:: total_load
         Whether a total-load file is being used (True) or not (False).
@@ -359,7 +359,7 @@ class HpcSimulation(
             total_load = True
             total_load_file = total_load_input
 
-        output: str = input_data.get("ouptut", "simulation_outputs")
+        output: str = input_data.get("output", "simulation_outputs")
 
         try:
             pv_system_size: float = float(input_data["pv_system_size"])

--- a/src/clover/scripts/hpc_utils.py
+++ b/src/clover/scripts/hpc_utils.py
@@ -110,7 +110,11 @@ class _BaseHpcRun:  # pylint: disable=too-few-public-methods
     type: HpcRunType
 
     def __init__(
-        self, location: str, output: str, total_load: bool, total_load_file: Optional[str] = None
+        self,
+        location: str,
+        output: str,
+        total_load: bool,
+        total_load_file: Optional[str] = None,
     ) -> None:
         """
         Instantiate a :class:`_BaseHpcRun` instance.
@@ -297,8 +301,8 @@ class HpcSimulation(
     def __init__(
         self,
         location: str,
-        pv_system_size: float,
         output: str,
+        pv_system_size: float,
         scenario: str,
         storage_size: float,
         total_load: bool,


### PR DESCRIPTION
### Description
This pull request is being opened to resolve the :bug: bug #138 where Imperial College London's High-Performance Computer (HPC) was unable to run CLOVER across multiple locations due to conflicting log file names.

As this is a minor bugfix, the version of CLOVER will not be updated as none of the functionality or methodology of the model has been changed. Instead, this will simply be merged directly into v5.0.5 on the `master` branch.

### Linked Issues
This pull request:
* closes 138

### Unit tests
This pull request does not affect any unit tests as there is no unit or integration testing done on HPC-specific code or scripts.

### Note
This issue has no impact beyond a small number of HPC users based at Imperial College London whose use cases include running multiple optimisations for a single location.