### PR TITLE
:tada: Include optimisation and threshold criteria in outputs

### DIFF
--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -1231,6 +1231,7 @@ def main(  # pylint: disable=too-many-locals, too-many-statements
             save_optimisation(
                 disable_tqdm,
                 logger,
+                optimisation,
                 optimisation_inputs,
                 optimisation_number,
                 output,

--- a/src/clover/optimisation/__utils__.py
+++ b/src/clover/optimisation/__utils__.py
@@ -1028,11 +1028,7 @@ def recursive_iteration(  # pylint: disable=too-many-locals
         )
 
         # Run the simulation
-        (
-            _,
-            simulation_results,
-            system_details,
-        ) = energy_system.run_simulation(
+        (_, simulation_results, system_details,) = energy_system.run_simulation(
             int(component_sizes[RenewableEnergySource.CLEAN_WATER_PVT]),
             conventional_cw_source_profiles,
             converters,
@@ -1208,8 +1204,13 @@ def save_optimisation(
     # Add the optimisation parameter information.
     output_dict = {
         "optimisation_inputs": optimisation_inputs.to_dict(),
-        "optimisation_criteria": {key.value: value.value for key, value in optimisation.optimisation_criteria.items()},
-        "threshold_criteria": {key.value: value for key, value in optimisation.threshold_criteria.items()},
+        "optimisation_criteria": {
+            key.value: value.value
+            for key, value in optimisation.optimisation_criteria.items()
+        },
+        "threshold_criteria": {
+            key.value: value for key, value in optimisation.threshold_criteria.items()
+        },
         "scenario": scenario.to_dict(),
         "system_appraisals": system_appraisals_dict,
     }

--- a/src/clover/optimisation/__utils__.py
+++ b/src/clover/optimisation/__utils__.py
@@ -1028,7 +1028,11 @@ def recursive_iteration(  # pylint: disable=too-many-locals
         )
 
         # Run the simulation
-        (_, simulation_results, system_details,) = energy_system.run_simulation(
+        (
+            _,
+            simulation_results,
+            system_details,
+        ) = energy_system.run_simulation(
             int(component_sizes[RenewableEnergySource.CLEAN_WATER_PVT]),
             conventional_cw_source_profiles,
             converters,

--- a/src/clover/optimisation/__utils__.py
+++ b/src/clover/optimisation/__utils__.py
@@ -1158,6 +1158,7 @@ def recursive_iteration(  # pylint: disable=too-many-locals
 def save_optimisation(
     disable_tqdm: bool,
     logger: Logger,
+    optimisation: Optimisation,
     optimisation_inputs: OptimisationParameters,
     optimisation_number: int,
     output: str,
@@ -1207,6 +1208,8 @@ def save_optimisation(
     # Add the optimisation parameter information.
     output_dict = {
         "optimisation_inputs": optimisation_inputs.to_dict(),
+        "optimisation_criteria": {key.value: value.value for key, value in optimisation.optimisation_criteria.items()},
+        "threshold_criteria": {key.value: value for key, value in optimisation.threshold_criteria.items()},
         "scenario": scenario.to_dict(),
         "system_appraisals": system_appraisals_dict,
     }


### PR DESCRIPTION
### Description
This pull request is being opened to enhance the output files of CLOVER to include the optimisation criteria and threshold criteria used in the output files.

This introduces a small enhancement, rather than a feature, so will be introduced to the current beta release, `v5.0.7b2`.

The output files from optimisations now contain additional input information:
```diff
{
    "optimisation_inputs": {
        "clean_water_pvt_size_max": 0,
        "clean_water_pvt_size_min": 0,
        "clean_water_pvt_size_step": 1,
        ...
        "storage_size_max": 40,
        "storage_size_min": 10,
        "storage_size_step": 30
    },
+   "optimisation_criteria": {
+        "lcue": "minimise"
+    },
+   "threshold_criteria": {
+       "blackouts": 0.05
+    },
    ...
```

### Linked Issues
This pull request:
* closes 160.

### Unit tests
This pull request does not affect any unit tests.