### PR TITLE
170 inverter lifetime uses max years

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -23,8 +23,8 @@
         "id": "MIT"
     },
     "notes": "If you use this software, please cite it as below.",
-    "publication_date": "2023-01-27",
+    "publication_date": "2023-05-11",
     "title": "CLOVER",
     "upload_type": "software",
-    "version": "v5.0.7"
+    "version": "v5.0.7post1"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,6 @@ authors:
     given-names: Philip
     orcid: https://orcid.org/0000-0003-1117-5095
 title: CLOVER
-version: v5.0.7
+version: v5.0.7post1
 doi: 10.5281/zenodo.6925535
-date-released: 2023-02-22
+date-released: 2023-05-11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = clover-energy
-version = 5.0.7
+version = 5.0.7post1
 author = Phil Sandwell, Ben Winchester and Hamish Beath
 author_email = philip.sandwell@gmail.com,benedict.winchester@gmail.com,hamishbeath@outlook.com
 description = Continuous Lifetime Optimisation of Variable Electricity Resources

--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -17,7 +17,7 @@ the clover module from the command-line interface.
 
 """
 
-__version__ = "5.0.7"
+__version__ = "5.0.7post1"
 
 import datetime
 import logging

--- a/src/clover/impact/finance.py
+++ b/src/clover/impact/finance.py
@@ -290,7 +290,7 @@ def _inverter_expenditure(  # pylint: disable=too-many-locals
     # Initialise inverter replacement periods
     replacement_period = finance_inputs[ImpactingComponent.INVERTER.value][LIFETIME]
     replacement_intervals = pd.DataFrame(
-        np.arange(0, location.max_years, replacement_period)
+        np.arange(start_year, end_year, replacement_period)
     )
     replacement_intervals.columns = pd.Index([ColumnHeader.INSTALLATION_YEAR.value])
 

--- a/src/clover/impact/ghgs.py
+++ b/src/clover/impact/ghgs.py
@@ -519,7 +519,7 @@ def _calculate_inverter_ghgs(  # pylint: disable=too-many-locals
     # Calcualte inverter replacement periods
     replacement_period = int(ghg_inputs[ImpactingComponent.INVERTER.value][LIFETIME])
     replacement_intervals = pd.DataFrame(
-        np.arange(0, location.max_years, replacement_period)
+        np.arange(start_year, end_year, replacement_period)
     )
     replacement_intervals.columns = pd.Index([ColumnHeader.INSTALLATION_YEAR.value])
 


### PR DESCRIPTION
### Description
This PR resolves a bug whereby inverter costs and emissions extended beyond a user's range of selected start and end years and included all of the years for which solar data was downloaded. This resolves the outsanding bug #170.

### Linked Issues
This pull request:
* closes 70.

### Unit tests
This pull request will need to update unit and integration tests to reflect the discounted costs.