### PR TITLE
:bug: Attempt bugfix for simulations not specified

### DIFF
--- a/src/clover/scripts/hpc.py
+++ b/src/clover/scripts/hpc.py
@@ -167,6 +167,8 @@ def main(args: List[Any]) -> None:
                 str(hpc_run.pv_system_size),
                 "--storage-size",
                 str(hpc_run.storage_size),
+                "--scenario",
+                str(hpc_run.scenario),
             ]
         )
 

--- a/src/clover/scripts/hpc.py
+++ b/src/clover/scripts/hpc.py
@@ -169,6 +169,8 @@ def main(args: List[Any]) -> None:
                 str(hpc_run.storage_size),
                 "--scenario",
                 str(hpc_run.scenario),
+                "-a",
+                "-sp",
             ]
         )
 


### PR DESCRIPTION
### Description
This pull request is being opened to resolve #226, namely that simulations carried on the HPC at Imperial College London did not utilise a scenario specified in the HPC YAML file.

This pull request will be integrated into the ongoing developement of the `5.2.0` release as part of the graphical user interface in CLOVER, so no version update will be released at this time.

### Linked Issues
This pull request:
* closes 226.

### Unit tests
This pull request only impacts HPC code, so does not affect any unit tests.