### PR TITLE
:sparkles: Implement carbon price feature

### DIFF
--- a/src/clover/__main__.py
+++ b/src/clover/__main__.py
@@ -186,7 +186,9 @@ def _prepare_location(
     """
 
     # Prepare for locations that may have been created in a CLOVER 5.2 environment.
-    locations_foldername: str = os.path.join(os.path.expanduser("~"), "clover_locations")
+    locations_foldername: str = os.path.join(
+        os.path.expanduser("~"), "clover_locations"
+    )
 
     if not os.path.isdir(os.path.join(locations_foldername, location)):
         logger.error(

--- a/src/clover/__utils__.py
+++ b/src/clover/__utils__.py
@@ -96,6 +96,10 @@ __all__ = (
 #   Placeholder text to use when the renewables.ninja API token has not been specified.
 API_TOKEN_PLACEHOLDER_TEXT: str = "YOUR API TOKEN HERE"
 
+# Carbon pricing:
+#   Keyword used for parsing carbon-pricing information.
+CARBON_PRICING: str = "carbon_pricing"
+
 # Cold water:
 #   Used for parsing cold-water related information.
 COLD_WATER: str = "cold_water"
@@ -2210,6 +2214,62 @@ class HotWaterScenario:
 
 
 @dataclasses.dataclass
+class CarbonPricing:
+    """
+    Contains information about the carbon-pricing tariffs to apply.
+
+    .. attribute:: diesel
+        The carbon price associated with the diesel component, in $/kg.
+
+    .. attribute:: grid
+        The carbon price associated with the grid, in $/kg.
+
+    .. attribute:: system
+        The carbon price associated with the renewable local system, in $/kg.
+
+    .. attribute:: total
+        The total carbon price to apply to all installed assets and emissions, in $/kg.
+
+    """
+
+    diesel: float | None = None
+    grid: float | None = None
+    system: float | None = None
+    total: float | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Ensures that the carbon pricing strategy is ok.
+
+        If a total carbon price is provided, then the other values should not be
+        provided. Similarly, the other attributes should be mean that total is not
+        speficied if they are.
+
+        """
+
+        component_wise_carbon_prices: set[float | None] = {
+            self.diesel,
+            self.grid,
+            self.system,
+        }
+
+        if (self.total is not None and self.total) and any(
+            {entry is not None for entry in component_wise_carbon_prices}
+        ):
+            raise InputFileError(
+                "scenario_inputs",
+                "If using a total carbon price, must not specify the other values.",
+            )
+
+        # If no total carbon price is provided, then set the values to be zero on the
+        # non-specified component-wise carbon prices.
+        if self.total is None:
+            self.diesel = self.diesel if self.diesel is not None else 0
+            self.grid = self.grid if self.grid is not None else 0
+            self.system = self.system if self.system is not None else 0
+
+
+@dataclasses.dataclass
 class Scenario:
     """
     Represents a scenario being run.
@@ -2263,6 +2323,7 @@ class Scenario:
     """
 
     battery: bool
+    carbon_pricing: CarbonPricing
     demands: Demands
     desalination_scenario: DesalinationScenario | None
     diesel_scenario: DieselScenario
@@ -2405,8 +2466,18 @@ class Scenario:
         else:
             hot_water_scenario = None
 
+        # Determine the carbon pricing if specified.
+        if (
+            carbon_pricing_inputs := scenario_inputs.get(CARBON_PRICING, None)
+        ) is not None:
+            carbon_pricing = CarbonPricing(**carbon_pricing_inputs)
+
+        else:
+            carbon_pricing = CarbonPricing()
+
         return cls(
             scenario_inputs["battery"],
+            carbon_pricing,
             demands,
             desalination_scenario,
             diesel_scenario,

--- a/src/clover/fileparser.py
+++ b/src/clover/fileparser.py
@@ -997,7 +997,13 @@ def _parse_global_settings(logger: Logger) -> dict[str, Any]:
             )
 
     # Parse global settings.
-    if not os.path.isfile((global_settings_filepath:=os.path.join(os.path.expanduser("~"), GLOBAL_SETTINGS_FILE))):
+    if not os.path.isfile(
+        (
+            global_settings_filepath := os.path.join(
+                os.path.expanduser("~"), GLOBAL_SETTINGS_FILE
+            )
+        )
+    ):
         _create_global_setings_file()
 
     try:

--- a/src/clover/generation/__utils__.py
+++ b/src/clover/generation/__utils__.py
@@ -184,8 +184,10 @@ def _get_profile_from_rn(
         parsed_response = json.loads(session_url.text)
     except JSONDecodeError as e:  # pylint: disable=invalid-name
         # Check that the token was correctly specified, and provide helpful info if so.
-        if " " in (token:=session.headers["Authorization"]):
-            logger.error(f"Your API token contains spaces and is therefore not valid. Token used: '{token}'")
+        if " " in (token := session.headers["Authorization"]):
+            logger.error(
+                f"Your API token contains spaces and is therefore not valid. Token used: '{token}'"
+            )
             logger.info("Session text: %s", session_url.text)
             raise RenewablesNinjaError() from None
 
@@ -488,7 +490,11 @@ class BaseRenewablesNinjaThread(threading.Thread):
                 )
                 try:
                     data = _get_profile_output(
-                        str(self.global_settings_inputs.get(TOKEN, self.global_settings_inputs.get("token", None))),
+                        str(
+                            self.global_settings_inputs.get(
+                                TOKEN, self.global_settings_inputs.get("token", None)
+                            )
+                        ),
                         self.location,
                         self.logger,
                         self.profile_key,

--- a/src/clover/load/load.py
+++ b/src/clover/load/load.py
@@ -326,8 +326,13 @@ def _linear_population_hourly(
         ]
     )
 
+
 def _normalised_linear_population_hourly(
-    *, initial_community_size: int, final_community_size: int, num_growth_years: int, num_years_total
+    *,
+    initial_community_size: int,
+    final_community_size: int,
+    num_growth_years: int,
+    num_years_total,
 ) -> pd.DataFrame:
     """
     Function to generate a normalised growing population based on values.
@@ -357,12 +362,19 @@ def _normalised_linear_population_hourly(
     )
 
     # Append the static popultion
-    population = pd.concat([population, pd.DataFrame([final_community_size] * (8760 * (num_years_total - num_growth_years)))], axis=0)
+    population = pd.concat(
+        [
+            population,
+            pd.DataFrame(
+                [final_community_size] * (8760 * (num_years_total - num_growth_years))
+            ),
+        ],
+        axis=0,
+    )
 
     population = population.reset_index(drop=True)
 
     return population / initial_community_size
-
 
 
 def _population_growth_daily(
@@ -500,7 +512,11 @@ def _number_of_devices_daily(
                 )
             )
             # Normalise the ownership based on the initial value being a math.floor.
-            daily_ownership = pd.DataFrame(daily_ownership[0] * math.floor(daily_ownership[0].loc[0]) / daily_ownership[0].loc[0])
+            daily_ownership = pd.DataFrame(
+                daily_ownership[0]
+                * math.floor(daily_ownership[0].loc[0])
+                / daily_ownership[0].loc[0]
+            )
         logger.info(
             "Ownership for device %s calculated.",
             device.name,
@@ -732,8 +748,8 @@ def process_device_hourly_power(
     # If the hourly power usage file already exists, load the data in.
     logger.info("Processing hourly power profile for %s.", device.name)
     # if os.path.isfile(hourly_usage_filepath) and not regenerate:
-#     with open(hourly_usage_filepath, "r") as f:
-#         device_load: pd.DataFrame = pd.read_csv(f, header=None)
+    #     with open(hourly_usage_filepath, "r") as f:
+    #         device_load: pd.DataFrame = pd.read_csv(f, header=None)
     #     logger.info(
     #         "Hourly power profile for %s successfully read from file %s.",
     #         device.name,
@@ -748,11 +764,15 @@ def process_device_hourly_power(
                     f"{BColours.fail}Internal error processing device "
                     + f"'{device.name}', electric power unexpectedly `None`.{BColours.endc}",
                 )
-            device_load = hourly_device_usage * device.electric_power * _normalised_linear_population_hourly(
-                initial_community_size=location.community_size,
-                final_community_size=location.final_community_size,
-                num_growth_years=simulation.end_year - simulation.start_year,
-                num_years_total=location.max_years,
+            device_load = (
+                hourly_device_usage
+                * device.electric_power
+                * _normalised_linear_population_hourly(
+                    initial_community_size=location.community_size,
+                    final_community_size=location.final_community_size,
+                    num_growth_years=simulation.end_year - simulation.start_year,
+                    num_years_total=location.max_years,
+                )
             )
             logger.info(
                 "Electric hourly power usage for %s successfully computed.", device.name

--- a/src/clover/optimisation/appraisal.py
+++ b/src/clover/optimisation/appraisal.py
@@ -548,6 +548,7 @@ def _simulation_financial_appraisal(  # pylint: disable=too-many-locals
     clean_water_tank_addition: int,
     converter_addition: dict[Converter, int],
     diesel_addition: float,
+    environmental_appraisal: EnvironmentalAppraisal,
     finance_inputs: dict[str, Any],
     heat_exchanger_addition: int,
     hot_water_tank_addition: int,
@@ -576,6 +577,8 @@ def _simulation_financial_appraisal(  # pylint: disable=too-many-locals
             system this iteration.
         - diesel_addition:
             The additional diesel capacity added this iteration.
+        - environment_appraisal:
+            The environmental appraisal.
         - finance_inputs:
             The finance input information.
         - heat_exchanger_addition:
@@ -740,6 +743,24 @@ def _simulation_financial_appraisal(  # pylint: disable=too-many-locals
         end_year=system_details.end_year,
     )
 
+    # Apply the carbon pricing where relevant
+    if scenario.carbon_pricing.diesel is not None:
+        diesel_fuel_costs += (
+            environmental_appraisal.diesel_ghgs * scenario.carbon_pricing.diesel
+        )
+
+    if scenario.carbon_pricing.grid is not None:
+        grid_costs += environmental_appraisal.grid_ghgs * scenario.carbon_pricing.grid
+
+    if scenario.carbon_pricing.system is not None:
+        for resource_type, subsystem_cost in subsystem_equipment_costs.items():
+            subsystem_equipment_costs[resource_type] = (
+                subsystem_cost
+                + environmental_appraisal.new_equipment_ghgs
+                * technical_appraisal.power_consumed_fraction[resource_type]
+                * scenario.carbon_pricing.system
+            )
+
     # Apportion the grid running costs by the resource types.
     total_subsystem_costs: dict[ResourceType, float] = {
         resource_type: value
@@ -770,6 +791,10 @@ def _simulation_financial_appraisal(  # pylint: disable=too-many-locals
     total_system_cost = sum(total_subsystem_costs.values())
 
     total_cost = total_system_cost + kerosene_costs
+
+    # Apply the total carbon price if specified.
+    if (total_carbon_price := scenario.carbon_pricing.total) is not None:
+        total_cost += total_carbon_price * environmental_appraisal.total_ghgs
 
     # Return outputs
     return FinancialAppraisal(
@@ -1559,26 +1584,6 @@ def appraise_system(  # pylint: disable=too-many-locals
         finance_inputs, logger, scenario, simulation_results, system_details
     )
 
-    financial_appraisal = _simulation_financial_appraisal(
-        buffer_tank_addition,
-        clean_water_tank_addition,
-        converter_addition,
-        diesel_addition,
-        finance_inputs,
-        heat_exchanger_addition,
-        hot_water_tank_addition,
-        inverter,
-        location,
-        logger,
-        pv_addition,
-        pvt_addition,
-        scenario,
-        simulation_results,
-        storage_addition,
-        system_details,
-        technical_appraisal,
-        electric_yearly_load_statistics,
-    )
     environmental_appraisal = _simulation_environmental_appraisal(
         buffer_tank_addition,
         clean_water_tank_addition,
@@ -1600,6 +1605,27 @@ def appraise_system(  # pylint: disable=too-many-locals
         storage_addition,
         system_details,
         technical_appraisal,
+    )
+    financial_appraisal = _simulation_financial_appraisal(
+        buffer_tank_addition,
+        clean_water_tank_addition,
+        converter_addition,
+        diesel_addition,
+        environmental_appraisal,
+        finance_inputs,
+        heat_exchanger_addition,
+        hot_water_tank_addition,
+        inverter,
+        location,
+        logger,
+        pv_addition,
+        pvt_addition,
+        scenario,
+        simulation_results,
+        storage_addition,
+        system_details,
+        technical_appraisal,
+        electric_yearly_load_statistics,
     )
 
     # Get results that rely on metrics of different kinds and several different
@@ -1627,6 +1653,9 @@ def appraise_system(  # pylint: disable=too-many-locals
         cumulative_results.subsystem_costs[ResourceType.ELECTRIC]
         / cumulative_results.discounted_electricity
     )
+    import pdb
+
+    pdb.set_trace()
     lcu_energy = float(
         cumulative_results.system_cost / cumulative_results.discounted_energy
     )


### PR DESCRIPTION
### Description
This pull request is being opened to introduce the carbon-pricing feature into the stranded-assets-analysis branch, used for the publication concerning asset stranding in Uttar Pradesh.

Carbon pricing enables a user to specify a cost associated with carbon emissions produced. For every unit of emissions produced (taken as kgCO2-eq) a cost can be included which is then applied when working out the total cost of the components. This cost can be broken down based on component:
- diesel, which is applied to the diesel costs (fuel and capacity, if relevant),
- grid, which is applied to emissions associated with energy drawn from the national grid as well as infrastructure emissions,
- system, which is applied to the local renewable energy system;
or can be specified as a `total` cost.

### Linked Issues
This pull request is not associated with any issues.

### Unit tests
This pull request has no associated unit tests.